### PR TITLE
Comment out mime.types inclusion in nginx.conf

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -23,7 +23,7 @@ http {
     # server_names_hash_bucket_size 64;
     # server_name_in_redirect off;
 
-    include /etc/nginx/mime.types;
+    # include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
     ##


### PR DESCRIPTION
Comment out the inclusion of mime.types in nginx configuration.