### PR TITLE
#131 add ET/EN i18n with svelte-i18n

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
                 "prettier-plugin-tailwindcss": "^0.7.2",
                 "svelte": "^5.49.2",
                 "svelte-check": "^4.3.6",
+                "svelte-i18n": "^4.0.1",
                 "tailwind-merge": "^3.4.1",
                 "tailwind-variants": "^3.2.2",
                 "tailwindcss": "^4.1.18",
@@ -714,6 +715,62 @@
             "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@formatjs/ecma402-abstract": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+            "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@formatjs/fast-memoize": "2.2.7",
+                "@formatjs/intl-localematcher": "0.6.2",
+                "decimal.js": "^10.4.3",
+                "tslib": "^2.8.0"
+            }
+        },
+        "node_modules/@formatjs/fast-memoize": {
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+            "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.0"
+            }
+        },
+        "node_modules/@formatjs/icu-messageformat-parser": {
+            "version": "2.11.4",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+            "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@formatjs/ecma402-abstract": "2.3.6",
+                "@formatjs/icu-skeleton-parser": "1.8.16",
+                "tslib": "^2.8.0"
+            }
+        },
+        "node_modules/@formatjs/icu-skeleton-parser": {
+            "version": "1.8.16",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+            "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@formatjs/ecma402-abstract": "2.3.6",
+                "tslib": "^2.8.0"
+            }
+        },
+        "node_modules/@formatjs/intl-localematcher": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+            "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.0"
+            }
         },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
@@ -2250,6 +2307,23 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/cli-color": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.4.tgz",
+            "integrity": "sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d": "^1.0.1",
+                "es5-ext": "^0.10.64",
+                "es6-iterator": "^2.0.3",
+                "memoizee": "^0.4.15",
+                "timers-ext": "^0.1.7"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
         "node_modules/clsx": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2325,6 +2399,20 @@
                 "node": ">=4"
             }
         },
+        "node_modules/d": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+            "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "es5-ext": "^0.10.64",
+                "type": "^2.7.2"
+            },
+            "engines": {
+                "node": ">=0.12"
+            }
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2342,6 +2430,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -2407,6 +2502,62 @@
             "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/es5-ext": {
+            "version": "0.10.64",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+            "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "ISC",
+            "dependencies": {
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.3",
+                "esniff": "^2.0.1",
+                "next-tick": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "node_modules/es6-symbol": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+            "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d": "^1.0.2",
+                "ext": "^1.7.0"
+            },
+            "engines": {
+                "node": ">=0.12"
+            }
+        },
+        "node_modules/es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
+            }
         },
         "node_modules/esbuild": {
             "version": "0.27.3",
@@ -2636,6 +2787,22 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/esniff": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+            "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d": "^1.0.1",
+                "es5-ext": "^0.10.62",
+                "event-emitter": "^0.3.5",
+                "type": "^2.7.2"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
         "node_modules/espree": {
             "version": "10.4.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -2720,6 +2887,17 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
+            }
+        },
         "node_modules/expect-type": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2728,6 +2906,16 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=12.0.0"
+            }
+        },
+        "node_modules/ext": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+            "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "type": "^2.7.2"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -2861,6 +3049,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/globalyzer": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+            "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/globrex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+            "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2922,6 +3124,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/intl-messageformat": {
+            "version": "10.7.18",
+            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+            "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@formatjs/ecma402-abstract": "2.3.6",
+                "@formatjs/fast-memoize": "2.2.7",
+                "@formatjs/icu-messageformat-parser": "2.11.4",
+                "tslib": "^2.8.0"
+            }
+        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2944,6 +3159,13 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/is-promise": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-reference": {
             "version": "3.0.3",
@@ -3348,6 +3570,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/lru-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+            "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es5-ext": "~0.10.2"
+            }
+        },
         "node_modules/lz-string": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -3366,6 +3598,26 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/memoizee": {
+            "version": "0.4.17",
+            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+            "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "d": "^1.0.2",
+                "es5-ext": "^0.10.64",
+                "es6-weak-map": "^2.0.3",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.2.2",
+                "lru-queue": "^0.1.0",
+                "next-tick": "^1.1.0",
+                "timers-ext": "^0.1.7"
+            },
+            "engines": {
+                "node": ">=0.12"
             }
         },
         "node_modules/minimatch": {
@@ -3433,6 +3685,13 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/next-tick": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+            "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/obug": {
             "version": "2.1.1",
@@ -4186,6 +4445,468 @@
                 }
             }
         },
+        "node_modules/svelte-i18n": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/svelte-i18n/-/svelte-i18n-4.0.1.tgz",
+            "integrity": "sha512-jaykGlGT5PUaaq04JWbJREvivlCnALtT+m87Kbm0fxyYHynkQaxQMnIKHLm2WeIuBRoljzwgyvz0Z6/CMwfdmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cli-color": "^2.0.3",
+                "deepmerge": "^4.2.2",
+                "esbuild": "^0.19.2",
+                "estree-walker": "^2",
+                "intl-messageformat": "^10.5.3",
+                "sade": "^1.8.1",
+                "tiny-glob": "^0.2.9"
+            },
+            "bin": {
+                "svelte-i18n": "dist/cli.js"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "peerDependencies": {
+                "svelte": "^3 || ^4 || ^5"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+            "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/android-arm": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+            "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/android-arm64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+            "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/android-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+            "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+            "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/darwin-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+            "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+            "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+            "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/linux-arm": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+            "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/linux-arm64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+            "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/linux-ia32": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+            "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/linux-loong64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+            "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+            "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+            "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+            "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/linux-s390x": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+            "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/linux-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+            "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+            "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+            "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/sunos-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+            "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/win32-arm64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+            "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/win32-ia32": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+            "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/@esbuild/win32-x64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+            "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/esbuild": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+            "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.19.12",
+                "@esbuild/android-arm": "0.19.12",
+                "@esbuild/android-arm64": "0.19.12",
+                "@esbuild/android-x64": "0.19.12",
+                "@esbuild/darwin-arm64": "0.19.12",
+                "@esbuild/darwin-x64": "0.19.12",
+                "@esbuild/freebsd-arm64": "0.19.12",
+                "@esbuild/freebsd-x64": "0.19.12",
+                "@esbuild/linux-arm": "0.19.12",
+                "@esbuild/linux-arm64": "0.19.12",
+                "@esbuild/linux-ia32": "0.19.12",
+                "@esbuild/linux-loong64": "0.19.12",
+                "@esbuild/linux-mips64el": "0.19.12",
+                "@esbuild/linux-ppc64": "0.19.12",
+                "@esbuild/linux-riscv64": "0.19.12",
+                "@esbuild/linux-s390x": "0.19.12",
+                "@esbuild/linux-x64": "0.19.12",
+                "@esbuild/netbsd-x64": "0.19.12",
+                "@esbuild/openbsd-x64": "0.19.12",
+                "@esbuild/sunos-x64": "0.19.12",
+                "@esbuild/win32-arm64": "0.19.12",
+                "@esbuild/win32-ia32": "0.19.12",
+                "@esbuild/win32-x64": "0.19.12"
+            }
+        },
+        "node_modules/svelte-i18n/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/svelte-toolbelt": {
             "version": "0.10.6",
             "resolved": "https://registry.npmjs.org/svelte-toolbelt/-/svelte-toolbelt-0.10.6.tgz",
@@ -4264,6 +4985,31 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/timers-ext": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+            "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "es5-ext": "^0.10.64",
+                "next-tick": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.12"
+            }
+        },
+        "node_modules/tiny-glob": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+            "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "globalyzer": "0.1.0",
+                "globrex": "^0.1.2"
             }
         },
         "node_modules/tinybench": {
@@ -4349,6 +5095,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/Wombosvideo"
             }
+        },
+        "node_modules/type": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+            "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
         "prettier-plugin-tailwindcss": "^0.7.2",
         "svelte": "^5.49.2",
         "svelte-check": "^4.3.6",
+        "svelte-i18n": "^4.0.1",
         "tailwind-merge": "^3.4.1",
         "tailwind-variants": "^3.2.2",
         "tailwindcss": "^4.1.18",

--- a/frontend/src/lib/components/AddPage/AddForm.svelte
+++ b/frontend/src/lib/components/AddPage/AddForm.svelte
@@ -4,7 +4,7 @@
     <div class="w-full max-w-2xl p-6 rounded-xl border border-gray-200 bg-white shadow-sm">
 
         <div class="mb-5">
-            <label for="category" class="block text-sm font-medium text-gray-700 mb-2">Category</label>
+            <label for="category" class="block text-sm font-medium text-gray-700 mb-2">{$_('add.category')}</label>
 
             {#if !addingNew && categories.length > 0}
                 <select class="flex h-9 w-full min-w-0 rounded-md border border-input bg-background px-3 py-1 text-base shadow-sm
@@ -12,7 +12,7 @@
                 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50
                 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
                         bind:value={selectedCategoryName}>
-                    <option value="" disabled>Select category</option>
+                    <option value="" disabled>{$_('add.selectCategory')}</option>
                     {#each categories as category (category.id)}
                         <option value={category.name}>{category.name}</option>
                     {/each}
@@ -22,7 +22,7 @@
             {#if addingNew}
                 <Input
                         class="flex-1"
-                        placeholder="Enter new category"
+                        placeholder={$_('add.newCategoryPlaceholder')}
                         bind:value={newCategoryName}
                 />
             {/if}
@@ -43,10 +43,10 @@
                 >
                     <span class="flex items-center gap-2">
                         {#if addingNew}
-                            Cancel
+                            {$_('common.cancel')}
                         {:else}
                             <Plus class="w-4 h-4"/>
-                            Add new
+                            {$_('add.addNew')}
                         {/if}
                     </span>
                 </Button>
@@ -59,7 +59,7 @@
                 >
                     <span class="flex items-center gap-2">
                         <Pencil class="w-4 h-4"/>
-                        Manage categories
+                        {$_('add.manageCategories')}
                     </span>
                 </Button>
             </div>
@@ -67,19 +67,19 @@
 
 
         <div class="mb-5">
-            <label for="word" class="block text-sm font-medium text-gray-700 mb-1">Word</label>
+            <label for="word" class="block text-sm font-medium text-gray-700 mb-1">{$_('add.word')}</label>
             <Input
                     id="word"
                     type="text"
                     bind:value={word}
-                    placeholder="Enter the word"
+                    placeholder={$_('add.wordPlaceholder')}
                     class="w-full border-gray-300 focus:ring-blue-400 focus:border-blue-400"
             />
         </div>
 
         <div class="mb-5 mt-8">
             <div class="flex items-center justify-between mb-1">
-                <label for="explanation" class="block text-sm font-medium text-gray-700">Explanation</label>
+                <label for="explanation" class="block text-sm font-medium text-gray-700">{$_('add.explanation')}</label>
                 <div class="relative" bind:this={ekiDropdownRef}>
                     <Button
                             type="button"
@@ -91,10 +91,10 @@
                         <span class="flex items-center gap-1.5 text-xs">
                             {#if ekiLoading}
                                 <BookOpen class="w-3.5 h-3.5 animate-spin" />
-                                Loading…
+                                {$_('add.ekiLoading')}
                             {:else}
                                 <BookOpen class="w-3.5 h-3.5" />
-                                EKI explanation (ET)
+                                {$_('add.ekiButton')}
                             {/if}
                         </span>
                     </Button>
@@ -128,7 +128,7 @@
             <Textarea
                     id="explanation"
                     bind:value={explanation}
-                    placeholder="Enter the explanation or description"
+                    placeholder={$_('add.explanationPlaceholder')}
                     class="w-full border-gray-300 focus:ring-blue-400 focus:border-blue-400 rounded-md min-h-[120px]"
             />
         </div>
@@ -140,7 +140,7 @@
                     disabled={!word.trim() || !explanation || !(selectedCategoryName || newCategoryName.trim()) || loading}
                     on:click={saveWord}
             >
-                {#if loading}Saving...{:else}Submit{/if}
+                {#if loading}{$_('common.saving')}{:else}{$_('add.submit')}{/if}
             </Button>
         </div>
 
@@ -151,7 +151,7 @@
 {#if manageModalOpen}
     <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
         <div class="bg-white p-6 rounded-md max-w-md w-full">
-            <h2 class="text-lg font-semibold mb-4">Edit Categories</h2>
+            <h2 class="text-lg font-semibold mb-4">{$_('add.editCategoriesTitle')}</h2>
 
             <div class="space-y-2 max-h-80 overflow-y-auto">
                 {#each categories as category (category.id)}
@@ -162,7 +162,7 @@
                         />
 
                         <Button size="sm" variant="outline" on:click={() => saveCategory(category)}>
-                            Save
+                            {$_('common.save')}
                         </Button>
 
                         <Button
@@ -180,14 +180,14 @@
 
                     {#if category.wordCount > 0}
                         <p class="text-xs text-gray-500 ml-1">
-                            Used in {category.wordCount} word(s)
+                            {$_('add.usedInWords', { values: { count: category.wordCount } })}
                         </p>
                     {/if}
                 {/each}
             </div>
 
             <div class="flex justify-end mt-4">
-                <Button variant="outline" on:click={closeManageModal}>Close</Button>
+                <Button variant="outline" on:click={closeManageModal}>{$_('common.close')}</Button>
             </div>
         </div>
     </div>
@@ -201,6 +201,7 @@
     import {fetchCategories} from '$lib/services/categoryService';
     import {Plus, Pencil, Trash2, BookOpen} from '@lucide/svelte';
     import {onMount} from 'svelte';
+    import { _ } from 'svelte-i18n';
 
     let word = '';
     let explanation = '';
@@ -233,14 +234,14 @@
 
     async function saveCategory(category: { id: number; name: string }) {
         if (!category.id) {
-            alert('Invalid category ID');
+            alert($_('add.invalidCategoryId'));
             return;
         }
         try {
             await GlossarClient.updateCategory(category.id, category.name);
-            alert('Category updated!');
+            alert($_('add.categoryUpdated'));
         } catch (err) {
-            alert(err instanceof Error ? err.message : 'Failed to update category');
+            alert(err instanceof Error ? err.message : $_('add.failedUpdateCategory'));
         }
     }
 
@@ -249,7 +250,7 @@
         try {
             await reloadCategories();
         } catch (err) {
-            alert('Failed to reload categories');
+            alert($_('add.failedReloadCategories'));
         }
     }
 
@@ -261,14 +262,14 @@
             const explanationGroups = await GlossarClient.fetchEkiExplanations(word.trim());
             const allExplanations = explanationGroups.flatMap(group => group.explanations);
             if (allExplanations.length === 0) {
-                ekiError = 'No explanation found in EKI for this word.';
+                ekiError = $_('add.ekiNoResult');
             } else if (allExplanations.length === 1) {
                 explanation = allExplanations[0];
             } else {
                 ekiExplanations = explanationGroups;
             }
         } catch {
-            ekiError = 'EKI search for explanation failed';
+            ekiError = $_('add.ekiFailed');
         } finally {
             ekiLoading = false;
         }
@@ -296,7 +297,7 @@
             const finalCategoryName = addingNew ? newCategoryName.trim() : selectedCategoryName;
 
             if (!finalCategoryName) {
-                alert('Please select or enter a category.');
+                alert($_('add.selectOrEnterCategory'));
                 return;
             }
 
@@ -312,27 +313,27 @@
             try {
                 await reloadCategories();
             } catch (err) {
-                alert('Failed to reload categories');
+                alert($_('add.failedReloadCategories'));
             }
 
-            alert('Word saved successfully!');
+            alert($_('add.wordSaved'));
         } catch (err) {
-            alert('Error saving word.');
+            alert($_('add.errorSavingWord'));
         } finally {
             loading = false;
         }
     }
 
     async function deleteCategory(category: { id: number; name: string }) {
-        if (!confirm(`Delete category "${category.name}"?`)) return;
+        if (!confirm($_('add.confirmDeleteCategory', { values: { name: category.name } }))) return;
 
         try {
             await GlossarClient.deleteCategory(category.id);
             await reloadCategories();
 
-            alert('Category deleted!');
+            alert($_('add.categoryDeleted'));
         } catch (err) {
-            alert(err instanceof Error ? err.message : 'Failed to delete category');
+            alert(err instanceof Error ? err.message : $_('add.failedDeleteCategory'));
         }
     }
 

--- a/frontend/src/lib/components/ConfirmModal.svelte
+++ b/frontend/src/lib/components/ConfirmModal.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
+    import { _ } from 'svelte-i18n';
 
     export let open = false;
-    export let title = 'Please confirm';
+    export let title: string | undefined = undefined;
     export let message = '';
-    export let confirmText = 'Confirm';
-    export let cancelText = 'Cancel';
+    export let confirmText: string | undefined = undefined;
+    export let cancelText: string | undefined = undefined;
     export let loading = false;
+
+    $: resolvedTitle = title ?? $_('confirm.defaultTitle');
+    $: resolvedConfirm = confirmText ?? $_('common.confirm');
+    $: resolvedCancel = cancelText ?? $_('common.cancel');
 
     const dispatch = createEventDispatcher<{
         confirm: void;
@@ -37,11 +42,11 @@
         class="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4"
         role="dialog"
         aria-modal="true"
-        aria-label={title}
+        aria-label={resolvedTitle}
         on:click={onBackdropClick}
     >
         <div class="w-full max-w-sm rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
-            <h3 class="text-lg font-semibold text-zinc-900">{title}</h3>
+            <h3 class="text-lg font-semibold text-zinc-900">{resolvedTitle}</h3>
             <p class="mt-2 text-sm text-zinc-600">{message}</p>
 
             <div class="mt-5 flex justify-end gap-2">
@@ -51,7 +56,7 @@
                     on:click={onCancel}
                     disabled={loading}
                 >
-                    {cancelText}
+                    {resolvedCancel}
                 </button>
                 <button
                     type="button"
@@ -59,7 +64,7 @@
                     on:click={onConfirm}
                     disabled={loading}
                 >
-                    {#if loading}Deleting...{:else}{confirmText}{/if}
+                    {#if loading}{$_('common.deleting')}{:else}{resolvedConfirm}{/if}
                 </button>
             </div>
         </div>

--- a/frontend/src/lib/components/EditWordModal.svelte
+++ b/frontend/src/lib/components/EditWordModal.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
+    import { _ } from 'svelte-i18n';
 
     export let open = false;
-    export let title = 'Edit word';
+    export let title: string | undefined = undefined;
     export let initialWord = '';
     export let initialExplanation = '';
     export let loading = false;
@@ -21,6 +22,8 @@
         save: { word: string; explanation: string; categoryName: string };
         cancel: void;
     }>();
+
+    $: resolvedTitle = title ?? $_('edit.title');
 
     $: if (open && (initialWord !== snapshotWord ||
             initialExplanation !== snapshotExplanation ||
@@ -69,14 +72,14 @@
         class="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4"
         role="dialog"
         aria-modal="true"
-        aria-label={title}
+        aria-label={resolvedTitle}
         on:click={onBackdropClick}
     >
         <form class="w-full max-w-sm rounded-xl border border-zinc-200 bg-white p-5 shadow-sm" on:submit={onSubmit}>
-            <h3 class="text-lg font-semibold text-zinc-900">{title}</h3>
+            <h3 class="text-lg font-semibold text-zinc-900">{resolvedTitle}</h3>
 
             <div class="mt-4 grid gap-3">
-                <label for="edit-word" class="text-sm font-medium text-zinc-700">Word</label>
+                <label for="edit-word" class="text-sm font-medium text-zinc-700">{$_('edit.word')}</label>
                 <input
                     id="edit-word"
                     class="h-10 rounded-lg border border-zinc-300 px-3 text-sm"
@@ -85,7 +88,7 @@
                     disabled={loading}
                 />
 
-                <label for="edit-explanation" class="text-sm font-medium text-zinc-700">Explanation</label>
+                <label for="edit-explanation" class="text-sm font-medium text-zinc-700">{$_('edit.explanation')}</label>
                 <textarea
                     id="edit-explanation"
                     class="min-h-24 rounded-lg border border-zinc-300 px-3 py-2 text-sm"
@@ -93,7 +96,7 @@
                     disabled={loading}
                 />
 
-                <label for="edit-category" class="text-sm font-medium text-zinc-700">Category</label>
+                <label for="edit-category" class="text-sm font-medium text-zinc-700">{$_('edit.category')}</label>
                 <select
                         id="edit-category"
                         class="h-10 rounded-lg border border-zinc-300 px-3 text-sm"
@@ -113,14 +116,14 @@
                     on:click={onCancel}
                     disabled={loading}
                 >
-                    Cancel
+                    {$_('common.cancel')}
                 </button>
                 <button
                     type="submit"
                     class="h-10 rounded-lg bg-zinc-900 px-4 text-sm font-semibold text-white disabled:opacity-60"
                     disabled={loading || !word.trim()}
                 >
-                    {#if loading}Saving...{:else}Save{/if}
+                    {#if loading}{$_('common.saving')}{:else}{$_('common.save')}{/if}
                 </button>
             </div>
         </form>

--- a/frontend/src/lib/components/ListPage/List.svelte
+++ b/frontend/src/lib/components/ListPage/List.svelte
@@ -4,6 +4,7 @@
     import ConfirmModal from '$lib/components/ConfirmModal.svelte';
     import EditWordModal from '$lib/components/EditWordModal.svelte';
     import {GlossarClient} from "$lib/api/glossarClient";
+    import { _ } from 'svelte-i18n';
 
     type Word = {
         id: number;
@@ -110,7 +111,7 @@
             await GlossarClient.deleteWord(target.id);
 
             deleteTarget = null;
-            success = `Deleted "${target.word}"`;
+            success = $_('list.deletedToast', { values: { word: target.word } });
             await loadWords(fallbackPage);
         } catch (e) {
             error = e instanceof Error ? e.message : String(e);
@@ -147,7 +148,7 @@
             });
 
             editTarget = null;
-            success = `Updated "${payload.word}"`;
+            success = $_('list.updatedToast', { values: { word: payload.word } });
             await loadWords(page);
         } catch (e) {
             error = e instanceof Error ? e.message : String(e);
@@ -173,49 +174,49 @@
     {/if}
 
     <form on:submit|preventDefault={applyFilter} class="rounded-md border border-zinc-200 bg-white p-4 shadow-sm">
-        <h2 class="mb-3 text-base font-semibold">Search</h2>
+        <h2 class="mb-3 text-base font-semibold">{$_('list.search')}</h2>
         <div class="grid gap-3 sm:grid-cols-2">
-            <input bind:value={listSearch} placeholder="search by word/explanation"
+            <input bind:value={listSearch} placeholder={$_('list.searchPlaceholder')}
                    class="h-10 rounded-lg border border-zinc-300 px-3 text-sm sm:col-span-2"/>
             <select bind:value={size} class="h-10 rounded-lg border border-zinc-300 px-3 text-sm">
-                <option value={5}>5 per page</option>
-                <option value={10}>10 per page</option>
-                <option value={20}>20 per page</option>
-                <option value={50}>50 per page</option>
+                <option value={5}>{$_('list.perPage', { values: { count: 5 } })}</option>
+                <option value={10}>{$_('list.perPage', { values: { count: 10 } })}</option>
+                <option value={20}>{$_('list.perPage', { values: { count: 20 } })}</option>
+                <option value={50}>{$_('list.perPage', { values: { count: 50 } })}</option>
             </select>
             <select bind:value={sortBy} class="h-10 rounded-lg border border-zinc-300 px-3 text-sm">
-                <option value="word">Sort by word</option>
-                <option value="explanation">Sort by explanation</option>
+                <option value="word">{$_('list.sortByWord')}</option>
+                <option value="explanation">{$_('list.sortByExplanation')}</option>
             </select>
             <select bind:value={sortDir} class="h-10 rounded-lg border border-zinc-300 px-3 text-sm">
-                <option value="asc">Ascending (ASC)</option>
-                <option value="desc">Descending (DESC)</option>
+                <option value="asc">{$_('list.ascending')}</option>
+                <option value="desc">{$_('list.descending')}</option>
             </select>
             <button type="submit" disabled={filterLoading || wordsLoading}
                     class="h-10 rounded-lg border border-zinc-300 bg-white text-sm font-medium sm:col-span-2">
-                Done
+                {$_('common.done')}
             </button>
         </div>
     </form>
 
     <div class="mt-6 rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
         <div class="mb-3 flex items-center justify-between">
-            <h2 class="text-base font-semibold">Words</h2>
+            <h2 class="text-base font-semibold">{$_('list.words')}</h2>
             <span class="text-sm text-zinc-600">
                 {#if wordsLoading}
-                    Loading...
+                    {$_('common.loading')}
                 {:else}
-                    {totalItems} total | page {page + 1} / {Math.max(totalPages, 1)}
+                    {$_('list.totalPage', { values: { total: totalItems, page: page + 1, pages: Math.max(totalPages, 1) } })}
                 {/if}
             </span>
         </div>
 
         {#if wordsLoading}
-            <div class="rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-700">Loading words...
+            <div class="rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-700">{$_('list.loadingWords')}
             </div>
         {:else if words.length === 0}
             <div class="rounded-lg border border-dashed border-zinc-300 bg-zinc-50 px-4 py-6 text-center text-sm text-zinc-600">
-                No words yet.
+                {$_('list.noWords')}
             </div>
         {:else}
             <ul class="divide-y divide-zinc-200 overflow-hidden rounded-xl border border-zinc-200">
@@ -227,7 +228,7 @@
                                 <button
                                         type="button"
                                         class="rounded-lg p-2 text-zinc-500 transition hover:bg-zinc-100 hover:text-zinc-800"
-                                        aria-label={`Edit word ${item.word}`}
+                                        aria-label={$_('list.editWordAria', { values: { word: item.word } })}
                                         on:click={() => openEditModal(item)}
                                 >
                                     <Pencil class="h-4 w-4"/>
@@ -235,7 +236,7 @@
                                 <button
                                         type="button"
                                         class="rounded-lg p-2 text-zinc-500 transition hover:bg-red-50 hover:text-red-600"
-                                        aria-label={`Delete word ${item.word}`}
+                                        aria-label={$_('list.deleteWordAria', { values: { word: item.word } })}
                                         on:click={() => openDeleteModal(item)}
                                 >
                                     <Trash2 class="h-4 w-4"/>
@@ -243,7 +244,7 @@
                             </div>
                         </div>
                         <div class="mt-1 text-sm text-zinc-600">
-                            {item.explanation || 'No explanation'}
+                            {item.explanation || $_('list.noExplanation')}
                         </div>
                         <div class="mt-3">
                             <span class="rounded-full bg-blue-100 px-3 py-0.5 text-xs text-zinc-600">
@@ -257,12 +258,12 @@
             <div class="mt-4 flex items-center justify-between gap-3">
                 <button type="button" on:click={previousPage} disabled={!hasPrevious || wordsLoading}
                         class="h-10 rounded-lg border border-zinc-300 bg-white px-4 text-sm font-medium disabled:opacity-50">
-                    Prev
+                    {$_('list.prev')}
                 </button>
-                <div class="text-sm text-zinc-600">Showing {words.length} item(s)</div>
+                <div class="text-sm text-zinc-600">{$_('list.showingItems', { values: { count: words.length } })}</div>
                 <button type="button" on:click={nextPage} disabled={!hasNext || wordsLoading}
                         class="h-10 rounded-lg border border-zinc-300 bg-white px-4 text-sm font-medium disabled:opacity-50">
-                    Next
+                    {$_('list.next')}
                 </button>
             </div>
         {/if}
@@ -271,10 +272,10 @@
 
 <ConfirmModal
         open={deleteTarget !== null}
-        title="Delete word"
-        message={`Are you sure you want to delete word: "${deleteTarget?.word ?? ''}"?`}
-        confirmText="Delete"
-        cancelText="Cancel"
+        title={$_('list.deleteTitle')}
+        message={$_('list.deleteMessage', { values: { word: deleteTarget?.word ?? '' } })}
+        confirmText={$_('common.delete')}
+        cancelText={$_('common.cancel')}
         loading={deleteLoading}
         on:cancel={closeDeleteModal}
         on:confirm={confirmDelete}
@@ -282,7 +283,7 @@
 
 <EditWordModal
         open={editTarget !== null}
-        title="Edit word"
+        title={$_('edit.title')}
         initialWord={editTarget?.word ?? ''}
         initialExplanation={editTarget?.explanation ?? ''}
         initialCategory={editTarget?.categoryName ?? ''}

--- a/frontend/src/lib/components/LoginPage/Login.svelte
+++ b/frontend/src/lib/components/LoginPage/Login.svelte
@@ -1,6 +1,7 @@
 
 <script lang="ts">
     import { Button } from "$lib/components/ui/button/index.js";
+    import { _ } from 'svelte-i18n';
 
     type Provider = {
         name: string;
@@ -18,7 +19,7 @@
     {#each providers as provider (provider.name)}
         <Button variant="outline" href={provider.href}>
             <img src={provider.icon} alt={provider.name + " logo"} class="w-5 h-5" />
-            Login with {provider.name}
+            {$_('login.loginWith', { values: { provider: provider.name } })}
         </Button>
     {/each}
 </div>

--- a/frontend/src/lib/components/Navigation.svelte
+++ b/frontend/src/lib/components/Navigation.svelte
@@ -4,12 +4,13 @@
     import type { HTMLAttributes } from 'svelte/elements';
     import { page } from '$app/stores'; // TODO: deprecated
     import { isAuthenticated } from '$lib/stores/auth';
+    import { _ } from 'svelte-i18n';
 
     const routes = [
-        { name: 'Login', href: '/login', authenticated: false },
-        { name: 'Add', href: '/add', authenticated: true },
-        { name: 'List', href: '/list', authenticated: true },
-        { name: 'Quiz', href: '/quiz', authenticated: true },
+        { key: 'login', href: '/login', authenticated: false },
+        { key: 'add', href: '/add', authenticated: true },
+        { key: 'list', href: '/list', authenticated: true },
+        { key: 'quiz', href: '/quiz', authenticated: true },
     ];
 
     type ListItemProps = HTMLAttributes<HTMLAnchorElement> & {
@@ -40,7 +41,7 @@
     <NavigationMenu.List class="flex w-full p-1">
         {#each routes.filter((item) => !('authenticated' in item) || item.authenticated === $isAuthenticated) as item (item.href)}
             {@render ListItem({
-                title: item.name,
+                title: $_(`nav.${item.key}`),
                 href: item.href,
                 class: $page.url.pathname === item.href ? 'border-default' : ''
             })}

--- a/frontend/src/lib/components/QuizPage/Quiz.svelte
+++ b/frontend/src/lib/components/QuizPage/Quiz.svelte
@@ -2,6 +2,7 @@
     import { onMount } from 'svelte';
     import { Check } from '@lucide/svelte';
     import { GlossarClient, type QuizQuestion } from '$lib/api/glossarClient';
+    import { _ } from 'svelte-i18n';
 
     type Status = 'loading' | 'ready' | 'empty' | 'submitting' | 'error';
 
@@ -37,7 +38,7 @@
             question = await GlossarClient.getQuizQuestion() ?? null;
             status = question ? 'ready' : 'empty';
         } catch (e) {
-            error = e instanceof Error ? e.message : 'Failed to load question';
+            error = e instanceof Error ? e.message : $_('quiz.failedLoad');
             status = 'error';
         }
     }
@@ -49,7 +50,7 @@
         try {
             await GlossarClient.submitQuizAnswer(question.wordId, selected === question.correctIndex);
         } catch (e) {
-            submitError = e instanceof Error ? e.message : 'Failed to save answer';
+            submitError = e instanceof Error ? e.message : $_('quiz.failedSave');
         }
         await loadQuestion();
     }
@@ -59,7 +60,7 @@
 
 <div class="space-y-6">
     {#if status === 'loading'}
-        <div class="py-12 text-center text-sm text-zinc-500">Loading...</div>
+        <div class="py-12 text-center text-sm text-zinc-500">{$_('common.loading')}</div>
 
     {:else if status === 'error'}
         <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-center text-sm text-red-600">
@@ -69,17 +70,17 @@
             onclick={loadQuestion}
             class="w-full rounded-xl border border-zinc-300 bg-white py-2.5 text-sm font-medium hover:bg-zinc-50"
         >
-            Try again
+            {$_('common.tryAgain')}
         </button>
 
     {:else if status === 'empty'}
         <div class="py-12 text-center text-sm text-zinc-500">
-            Add some words to your dictionary to start quizzing!
+            {$_('quiz.empty')}
         </div>
 
     {:else if question}
         <p class="text-center text-base text-zinc-500">
-            What is: <span class="text-lg font-semibold text-zinc-900 underline">{question.word}</span>
+            {$_('quiz.whatIs')} <span class="text-lg font-semibold text-zinc-900 underline">{question.word}</span>
         </p>
 
         <div class="grid grid-cols-2 gap-2">
@@ -103,7 +104,7 @@
 
         {#if submitError}
             <div class="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-center text-xs text-amber-700">
-                Answer may not have been saved — {submitError}
+                {$_('quiz.answerNotSaved', { values: { error: submitError } })}
             </div>
         {/if}
 
@@ -112,7 +113,7 @@
             disabled={!isAnswered || status === 'submitting'}
             class="w-full rounded-xl border border-zinc-300 bg-white py-2.5 text-sm font-medium hover:bg-zinc-50 disabled:opacity-50"
         >
-            {status === 'submitting' ? 'Saving...' : 'Next'}
+            {status === 'submitting' ? $_('common.saving') : $_('list.next')}
         </button>
     {/if}
 </div>

--- a/frontend/src/lib/i18n/index.ts
+++ b/frontend/src/lib/i18n/index.ts
@@ -1,0 +1,32 @@
+import { browser } from '$app/environment';
+import { init, register, locale } from 'svelte-i18n';
+
+export const SUPPORTED_LOCALES = ['et', 'en'] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+const DEFAULT_LOCALE: SupportedLocale = 'et';
+const STORAGE_KEY = 'glossaar.locale';
+
+register('et', () => import('./locales/et.json'));
+register('en', () => import('./locales/en.json'));
+
+function detectInitialLocale(): SupportedLocale {
+    if (!browser) return DEFAULT_LOCALE;
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored && (SUPPORTED_LOCALES as readonly string[]).includes(stored)) {
+        return stored as SupportedLocale;
+    }
+    return DEFAULT_LOCALE;
+}
+
+init({
+    fallbackLocale: DEFAULT_LOCALE,
+    initialLocale: detectInitialLocale()
+});
+
+export function setLocale(next: SupportedLocale) {
+    locale.set(next);
+    if (browser) {
+        window.localStorage.setItem(STORAGE_KEY, next);
+    }
+}

--- a/frontend/src/lib/i18n/index.ts
+++ b/frontend/src/lib/i18n/index.ts
@@ -1,4 +1,3 @@
-import { browser } from '$app/environment';
 import { init, register, locale } from 'svelte-i18n';
 
 export const SUPPORTED_LOCALES = ['et', 'en'] as const;
@@ -11,7 +10,6 @@ register('et', () => import('./locales/et.json'));
 register('en', () => import('./locales/en.json'));
 
 function detectInitialLocale(): SupportedLocale {
-    if (!browser) return DEFAULT_LOCALE;
     const stored = window.localStorage.getItem(STORAGE_KEY);
     if (stored && (SUPPORTED_LOCALES as readonly string[]).includes(stored)) {
         return stored as SupportedLocale;
@@ -26,7 +24,5 @@ init({
 
 export function setLocale(next: SupportedLocale) {
     locale.set(next);
-    if (browser) {
-        window.localStorage.setItem(STORAGE_KEY, next);
-    }
+    window.localStorage.setItem(STORAGE_KEY, next);
 }

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -1,0 +1,114 @@
+{
+    "common": {
+        "loading": "Loading...",
+        "cancel": "Cancel",
+        "confirm": "Confirm",
+        "save": "Save",
+        "saving": "Saving...",
+        "delete": "Delete",
+        "deleting": "Deleting...",
+        "close": "Close",
+        "done": "Done",
+        "tryAgain": "Try again",
+        "logout": "Log out"
+    },
+    "nav": {
+        "login": "Login",
+        "add": "Add",
+        "list": "List",
+        "quiz": "Quiz"
+    },
+    "pages": {
+        "add": {
+            "title": "Create a new word",
+            "subtitle": "Add a new word to your glossary."
+        },
+        "list": {
+            "title": "Word list",
+            "subtitle": "Here you can find all the words you have added."
+        },
+        "login": {
+            "title": "Log in",
+            "subtitle": "Log in with an OAuth provider of your choice."
+        },
+        "quiz": {
+            "title": "Quiz",
+            "subtitle": "Test your knowledge and learn new words!"
+        }
+    },
+    "add": {
+        "category": "Category",
+        "selectCategory": "Select category",
+        "newCategoryPlaceholder": "Enter new category",
+        "addNew": "Add new",
+        "manageCategories": "Manage categories",
+        "word": "Word",
+        "wordPlaceholder": "Enter the word",
+        "explanation": "Explanation",
+        "explanationPlaceholder": "Enter the explanation or description",
+        "ekiLoading": "Loading…",
+        "ekiButton": "EKI explanation (ET)",
+        "ekiNoResult": "No explanation found in EKI for this word.",
+        "ekiFailed": "EKI search for explanation failed",
+        "submit": "Submit",
+        "editCategoriesTitle": "Edit Categories",
+        "usedInWords": "Used in {count} word(s)",
+        "selectOrEnterCategory": "Please select or enter a category.",
+        "wordSaved": "Word saved successfully!",
+        "errorSavingWord": "Error saving word.",
+        "categoryUpdated": "Category updated!",
+        "categoryDeleted": "Category deleted!",
+        "confirmDeleteCategory": "Delete category \"{name}\"?",
+        "invalidCategoryId": "Invalid category ID",
+        "failedReloadCategories": "Failed to reload categories",
+        "failedUpdateCategory": "Failed to update category",
+        "failedDeleteCategory": "Failed to delete category"
+    },
+    "list": {
+        "search": "Search",
+        "searchPlaceholder": "search by word/explanation",
+        "perPage": "{count} per page",
+        "sortByWord": "Sort by word",
+        "sortByExplanation": "Sort by explanation",
+        "ascending": "Ascending (ASC)",
+        "descending": "Descending (DESC)",
+        "words": "Words",
+        "totalPage": "{total} total | page {page} / {pages}",
+        "loadingWords": "Loading words...",
+        "noWords": "No words yet.",
+        "noExplanation": "No explanation",
+        "showingItems": "Showing {count} item(s)",
+        "prev": "Prev",
+        "next": "Next",
+        "editWordAria": "Edit word {word}",
+        "deleteWordAria": "Delete word {word}",
+        "deleteTitle": "Delete word",
+        "deleteMessage": "Are you sure you want to delete word: \"{word}\"?",
+        "deletedToast": "Deleted \"{word}\"",
+        "updatedToast": "Updated \"{word}\""
+    },
+    "edit": {
+        "title": "Edit word",
+        "word": "Word",
+        "explanation": "Explanation",
+        "category": "Category"
+    },
+    "login": {
+        "loginWith": "Login with {provider}"
+    },
+    "quiz": {
+        "empty": "Add some words to your dictionary to start quizzing!",
+        "whatIs": "What is:",
+        "answerNotSaved": "Answer may not have been saved — {error}",
+        "failedLoad": "Failed to load question",
+        "failedSave": "Failed to save answer"
+    },
+    "confirm": {
+        "defaultTitle": "Please confirm"
+    },
+    "lang": {
+        "label": "Lang: {code}",
+        "et": "Eesti",
+        "en": "English"
+    }
+}

--- a/frontend/src/lib/i18n/locales/et.json
+++ b/frontend/src/lib/i18n/locales/et.json
@@ -1,0 +1,114 @@
+{
+    "common": {
+        "loading": "Laadimine...",
+        "cancel": "Tühista",
+        "confirm": "Kinnita",
+        "save": "Salvesta",
+        "saving": "Salvestamine...",
+        "delete": "Kustuta",
+        "deleting": "Kustutamine...",
+        "close": "Sulge",
+        "done": "Valmis",
+        "tryAgain": "Proovi uuesti",
+        "logout": "Logi välja"
+    },
+    "nav": {
+        "login": "Logi sisse",
+        "add": "Lisa",
+        "list": "Nimekiri",
+        "quiz": "Viktoriin"
+    },
+    "pages": {
+        "add": {
+            "title": "Loo uus sõna",
+            "subtitle": "Lisa uus sõna oma sõnastikku."
+        },
+        "list": {
+            "title": "Sõnade nimekiri",
+            "subtitle": "Siin on kõik sõnad, mille oled lisanud."
+        },
+        "login": {
+            "title": "Logi sisse",
+            "subtitle": "Logi sisse valitud OAuth pakkujaga."
+        },
+        "quiz": {
+            "title": "Viktoriin",
+            "subtitle": "Pane oma teadmised proovile ja õpi uusi sõnu!"
+        }
+    },
+    "add": {
+        "category": "Kategooria",
+        "selectCategory": "Vali kategooria",
+        "newCategoryPlaceholder": "Sisesta uus kategooria",
+        "addNew": "Lisa uus",
+        "manageCategories": "Halda kategooriaid",
+        "word": "Sõna",
+        "wordPlaceholder": "Sisesta sõna",
+        "explanation": "Selgitus",
+        "explanationPlaceholder": "Sisesta selgitus või kirjeldus",
+        "ekiLoading": "Laadimine…",
+        "ekiButton": "EKI selgitus (ET)",
+        "ekiNoResult": "Sellele sõnale ei leitud EKI-st selgitust.",
+        "ekiFailed": "EKI otsing ebaõnnestus",
+        "submit": "Salvesta sõna",
+        "editCategoriesTitle": "Muuda kategooriaid",
+        "usedInWords": "Kasutusel {count} sõnas",
+        "selectOrEnterCategory": "Palun vali või sisesta kategooria.",
+        "wordSaved": "Sõna salvestatud!",
+        "errorSavingWord": "Viga sõna salvestamisel.",
+        "categoryUpdated": "Kategooria uuendatud!",
+        "categoryDeleted": "Kategooria kustutatud!",
+        "confirmDeleteCategory": "Kas kustutada kategooria \"{name}\"?",
+        "invalidCategoryId": "Vigane kategooria ID",
+        "failedReloadCategories": "Kategooriate laadimine ebaõnnestus",
+        "failedUpdateCategory": "Kategooria uuendamine ebaõnnestus",
+        "failedDeleteCategory": "Kategooria kustutamine ebaõnnestus"
+    },
+    "list": {
+        "search": "Otsing",
+        "searchPlaceholder": "otsi sõna/selgituse järgi",
+        "perPage": "{count} lehe kohta",
+        "sortByWord": "Sorteeri sõna järgi",
+        "sortByExplanation": "Sorteeri selgituse järgi",
+        "ascending": "Kasvavalt (ASC)",
+        "descending": "Kahanevalt (DESC)",
+        "words": "Sõnad",
+        "totalPage": "{total} kokku | lehekülg {page} / {pages}",
+        "loadingWords": "Sõnade laadimine...",
+        "noWords": "Sõnu pole veel.",
+        "noExplanation": "Selgitus puudub",
+        "showingItems": "Näitan {count} kirjet",
+        "prev": "Eelmine",
+        "next": "Järgmine",
+        "editWordAria": "Muuda sõna {word}",
+        "deleteWordAria": "Kustuta sõna {word}",
+        "deleteTitle": "Kustuta sõna",
+        "deleteMessage": "Kas oled kindel, et soovid kustutada sõna: \"{word}\"?",
+        "deletedToast": "Kustutatud \"{word}\"",
+        "updatedToast": "Uuendatud \"{word}\""
+    },
+    "edit": {
+        "title": "Muuda sõna",
+        "word": "Sõna",
+        "explanation": "Selgitus",
+        "category": "Kategooria"
+    },
+    "login": {
+        "loginWith": "Logi sisse {provider}-ga"
+    },
+    "quiz": {
+        "empty": "Lisa oma sõnastikku sõnu, et alustada viktoriini!",
+        "whatIs": "Mis on:",
+        "answerNotSaved": "Vastust ei pruugitud salvestada — {error}",
+        "failedLoad": "Küsimuse laadimine ebaõnnestus",
+        "failedSave": "Vastuse salvestamine ebaõnnestus"
+    },
+    "confirm": {
+        "defaultTitle": "Palun kinnita"
+    },
+    "lang": {
+        "label": "Keel: {code}",
+        "et": "Eesti",
+        "en": "English"
+    }
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import './layout.css';
+    import '$lib/i18n';
     import favicon from '$lib/assets/favicon.svg';
     import Navigation from '$lib/components/Navigation.svelte';
     import { auth, isAuthenticated, isLoading } from '$lib/stores/auth';
@@ -8,6 +9,9 @@
     import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
     import { logout } from '$lib/services/authService';
     import { goto } from '$app/navigation';
+    import { locale, _ } from 'svelte-i18n';
+    import { buttonVariants } from '$lib/components/ui/button';
+    import { setLocale, SUPPORTED_LOCALES } from '$lib/i18n';
 
     onMount(async () => {
         await auth.init();
@@ -31,24 +35,43 @@
     <title>Glossaar</title>
 </svelte:head>
 
-{#if $isLoading}
+{#if $isLoading || !$locale}
     <div class="flex items-center justify-center h-screen">
-        <p class="text-lg text-zinc-500">Loading...</p>
+        <p class="text-lg text-zinc-500">{$locale ? $_('common.loading') : 'Loading...'}</p>
     </div>
 {:else}
     <div class="mx-auto my-2 h-full w-full max-w-[24.5rem] flex flex-col p-2 rounded-md border">
-        <div class="flex flex-row justify-between items-center sticky top-1 bg-white shadow-sm rounded-md border pr-1">
+        <div class="flex flex-row justify-between items-center sticky top-1 bg-white shadow-sm rounded-md border pr-1 gap-1">
             <Navigation />
-            {#if $isAuthenticated}
+            <div class="flex flex-row items-center gap-1">
                 <DropdownMenu.Root>
-                    <DropdownMenu.Trigger class="hover:cursor-pointer" >
-                        <UserAvatar />
+                    <DropdownMenu.Trigger
+                        class={buttonVariants({ variant: 'ghost', size: 'sm' }) + ' hover:cursor-pointer'}
+                    >
+                        {$_('lang.label', { values: { code: ($locale ?? '').slice(0, 2) } })}
                     </DropdownMenu.Trigger>
-                    <DropdownMenu.Content class="w-28" align="end">
-                        <DropdownMenu.Item class="hover:cursor-pointer" variant="destructive" onSelect={logout}>Log out</DropdownMenu.Item>
+                    <DropdownMenu.Content align="end">
+                        {#each SUPPORTED_LOCALES as code (code)}
+                            <DropdownMenu.Item
+                                class="hover:cursor-pointer"
+                                onSelect={() => setLocale(code)}
+                            >
+                                {$_(`lang.${code}`)} ({code.toUpperCase()})
+                            </DropdownMenu.Item>
+                        {/each}
                     </DropdownMenu.Content>
                 </DropdownMenu.Root>
-            {/if}
+                {#if $isAuthenticated}
+                    <DropdownMenu.Root>
+                        <DropdownMenu.Trigger class="hover:cursor-pointer" >
+                            <UserAvatar />
+                        </DropdownMenu.Trigger>
+                        <DropdownMenu.Content class="w-28" align="end">
+                            <DropdownMenu.Item class="hover:cursor-pointer" variant="destructive" onSelect={logout}>{$_('common.logout')}</DropdownMenu.Item>
+                        </DropdownMenu.Content>
+                    </DropdownMenu.Root>
+                {/if}
+            </div>
         </div>
         <main class="rounded-md py-4 flex flex-col gap-4">
             {@render children()}

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,0 +1,2 @@
+export const ssr = false;
+export const prerender = false;

--- a/frontend/src/routes/add/+page.svelte
+++ b/frontend/src/routes/add/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
     import PageHeader from '$lib/components/PageHeader.svelte';
     import AddForm from '$lib/components/AddPage/AddForm.svelte';
+    import { _ } from 'svelte-i18n';
 </script>
 
-<PageHeader title="Create a new word" subtitle="Add a new word to your glossary." />
+<PageHeader title={$_('pages.add.title')} subtitle={$_('pages.add.subtitle')} />
 <AddForm />

--- a/frontend/src/routes/list/+page.svelte
+++ b/frontend/src/routes/list/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
     import PageHeader from '$lib/components/PageHeader.svelte';
     import List from '$lib/components/ListPage/List.svelte';
+    import { _ } from 'svelte-i18n';
 </script>
 
-<PageHeader title="Word list" subtitle="Here you can find all the words you have added." />
+<PageHeader title={$_('pages.list.title')} subtitle={$_('pages.list.subtitle')} />
 <List />

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
     import PageHeader from '$lib/components/PageHeader.svelte';
     import Login from '$lib/components/LoginPage/Login.svelte';
+    import { _ } from 'svelte-i18n';
 </script>
 
-<PageHeader title="Log in" subtitle="Log in with an OAuth provider of your choice." />
+<PageHeader title={$_('pages.login.title')} subtitle={$_('pages.login.subtitle')} />
 <Login />

--- a/frontend/src/routes/login/page.svelte.spec.ts
+++ b/frontend/src/routes/login/page.svelte.spec.ts
@@ -2,6 +2,7 @@ import { page } from 'vitest/browser';
 import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 
+import '$lib/i18n';
 import Page from './+page.svelte';
 
 describe('/+page.svelte', () => {

--- a/frontend/src/routes/quiz/+page.svelte
+++ b/frontend/src/routes/quiz/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
     import PageHeader from '$lib/components/PageHeader.svelte';
     import Quiz from '$lib/components/QuizPage/Quiz.svelte';
+    import { _ } from 'svelte-i18n';
 </script>
 
-<PageHeader title="Quiz" subtitle="Test your knowledge and learn new words!" />
+<PageHeader title={$_('pages.quiz.title')} subtitle={$_('pages.quiz.subtitle')} />
 <Quiz />


### PR DESCRIPTION
Panin keele dropdown top menüüsse, mitte nagu meie prototüübi pildil, kus see asub all, sest sellisel juhul oleks see nähtaval ainult sõna lisamise vaates, mis tundus inconsistent Tahtsin, et rippmenüü oleks kättesaadav igas vaates, aga võib olla ei ole see nii vajalik, seega võib selle vajadusel või hiljem, kui disain selgub, mujale tõsta. Mis aga kindlasti üle vaatamist vajab, on eestikeelsed tõlked — palun vaadake need üle ja parandage kui vaja.