### PR TITLE
add ValidationException with localized frontend rendering

### DIFF
--- a/backend/src/main/java/com/glossaar/backend/ApiExceptionHandler.java
+++ b/backend/src/main/java/com/glossaar/backend/ApiExceptionHandler.java
@@ -15,11 +15,22 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
+import java.util.List;
 
 @RestControllerAdvice
 public class ApiExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(ApiExceptionHandler.class);
+
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity<ValidationErrorResponse> handleValidation(ValidationException ex, HttpServletRequest request) {
+        ValidationErrorResponse body = new ValidationErrorResponse(
+                "ValidationException." + ex.getMessage(),
+                ex.getArgs(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
 
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<ApiErrorResponse> handleResponseStatusException(ResponseStatusException ex, HttpServletRequest request) {
@@ -78,6 +89,13 @@ public class ApiExceptionHandler {
             int status,
             String error,
             String message,
+            String path
+    ) {
+    }
+
+    public record ValidationErrorResponse(
+            String error,
+            List<String> args,
             String path
     ) {
     }

--- a/backend/src/main/java/com/glossaar/backend/ValidationException.java
+++ b/backend/src/main/java/com/glossaar/backend/ValidationException.java
@@ -1,0 +1,25 @@
+package com.glossaar.backend;
+
+import java.util.List;
+
+public class ValidationException extends RuntimeException {
+
+    private final List<String> args;
+
+    public ValidationException(String message) {
+        this(message, List.of());
+    }
+
+    public ValidationException(String message, List<String> args) {
+        super(message);
+        this.args = args == null ? List.of() : List.copyOf(args);
+    }
+
+    public ValidationException(String message, String... args) {
+        this(message, args == null ? List.of() : List.of(args));
+    }
+
+    public List<String> getArgs() {
+        return args;
+    }
+}

--- a/backend/src/main/java/com/glossaar/backend/category/CategoryService.java
+++ b/backend/src/main/java/com/glossaar/backend/category/CategoryService.java
@@ -1,5 +1,6 @@
 package com.glossaar.backend.category;
 
+import com.glossaar.backend.ValidationException;
 import com.glossaar.backend.user.UserEntity;
 import com.glossaar.backend.word.WordRepository;
 import jakarta.transaction.Transactional;
@@ -44,7 +45,7 @@ public class CategoryService {
 
         String newName = name.trim();
         if (newName.isEmpty()) {
-            throw new IllegalArgumentException("Category name cannot be empty");
+            throw new ValidationException("field: blank", "name");
         }
 
         category.setName(newName);
@@ -53,10 +54,7 @@ public class CategoryService {
 
     private static String normalizeName(String field, String value) {
         if (value == null || value.trim().isEmpty()) {
-            throw new ResponseStatusException(
-                HttpStatus.BAD_REQUEST,
-                field + " must not be blank"
-            );
+            throw new ValidationException("field: blank", field);
         }
 
         String trimmed = value.trim();
@@ -80,10 +78,7 @@ public class CategoryService {
         long wordCount = wordRepository.countByCategory_IdAndUser(id, user);
 
         if (wordCount > 0) {
-            throw new ResponseStatusException(
-                HttpStatus.BAD_REQUEST,
-                "Cannot delete category: " + wordCount + " words reference it"
-            );
+            throw new ValidationException("category: hasWords", String.valueOf(wordCount));
         }
 
         repository.delete(category);

--- a/backend/src/main/java/com/glossaar/backend/quiz/QuizService.java
+++ b/backend/src/main/java/com/glossaar/backend/quiz/QuizService.java
@@ -1,5 +1,6 @@
 package com.glossaar.backend.quiz;
 
+import com.glossaar.backend.ValidationException;
 import com.glossaar.backend.category.CategoryRepository;
 import com.glossaar.backend.quiz.dto.QuizBatchAnswerRequestDto;
 import com.glossaar.backend.quiz.dto.QuizQuestionResponseDto;
@@ -45,10 +46,7 @@ public class QuizService {
                 ? quizRepository.findLowestScoreQuizWordsByUserId(userId, quizSetSize)
                 : quizRepository.findLowestScoreQuizWordsByUserIdAndCategoryId(userId, categoryId, quizSetSize);
         if (quizWords.size() < quizSetSize) {
-            throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST,
-                    "At least " + quizSetSize + " words with explanations are required for quiz for user: " + userId
-            );
+            throw new ValidationException("quiz: notEnoughWords", String.valueOf(quizSetSize));
         }
 
         List<QuizQuestionResponseDto> questionSet = new ArrayList<>(quizSetSize);
@@ -65,10 +63,7 @@ public class QuizService {
             options.addAll(distractors);
 
             if (options.size() < OPTIONS_PER_QUESTION) {
-                throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST,
-                    "At least " + OPTIONS_PER_QUESTION + " unique explanations are required in the vocabulary for quiz options"
-                );
+                throw new ValidationException("quiz: notEnoughDistractors", String.valueOf(OPTIONS_PER_QUESTION));
             }
 
             Collections.shuffle(options);
@@ -81,13 +76,10 @@ public class QuizService {
 
     private static int normalizeQuizSetSize(int requestedSize) {
         if (requestedSize < 1) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "size must be at least 1");
+            throw new ValidationException("size: outOfRange", "1", String.valueOf(MAX_QUIZ_SET_SIZE));
         }
         if (requestedSize > MAX_QUIZ_SET_SIZE) {
-            throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST,
-                    "size must be between 1 and " + MAX_QUIZ_SET_SIZE
-            );
+            throw new ValidationException("size: outOfRange", "1", String.valueOf(MAX_QUIZ_SET_SIZE));
         }
         return requestedSize;
     }
@@ -99,19 +91,13 @@ public class QuizService {
         }
 
         if (request.answers().size() > MAX_SUBMIT_BATCH_SIZE) {
-            throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST,
-                    "answers must contain at most " + MAX_SUBMIT_BATCH_SIZE + " items"
-            );
+            throw new ValidationException("answers: tooMany", String.valueOf(MAX_SUBMIT_BATCH_SIZE));
         }
 
         Set<Long> seenWordIds = new HashSet<>();
         for (QuizBatchAnswerRequestDto.QuizAnswerItemDto answer : request.answers()) {
             if (!seenWordIds.add(answer.wordId())) {
-                throw new ResponseStatusException(
-                        HttpStatus.BAD_REQUEST,
-                        "answers must not contain duplicate wordId values"
-                );
+                throw new ValidationException("answers: duplicateWordId");
             }
         }
 

--- a/backend/src/main/java/com/glossaar/backend/user/UserService.java
+++ b/backend/src/main/java/com/glossaar/backend/user/UserService.java
@@ -1,5 +1,6 @@
 package com.glossaar.backend.user;
 
+import com.glossaar.backend.ValidationException;
 import com.glossaar.backend.auth.OAuthAccount;
 import com.glossaar.backend.auth.OAuthAccountRepository;
 import com.glossaar.backend.auth.OAuthProvider;
@@ -51,7 +52,7 @@ public class UserService {
         String normalizedUsername = requireNonBlank("username", username);
 
         if (repository.existsByUsernameIgnoreCase(normalizedUsername)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "username already exists");
+            throw new ValidationException("username: exists");
         }
 
         try {
@@ -59,13 +60,13 @@ public class UserService {
                     new UserEntity(normalizedUsername, emailFromUsername(normalizedUsername)));
             return toResponse(saved);
         } catch (DataIntegrityViolationException ex) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "username already exists");
+            throw new ValidationException("username: exists");
         }
     }
 
     private static String requireNonBlank(String field, String value) {
         if (value == null || value.trim().isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, field + " must not be blank");
+            throw new ValidationException("field: blank", field);
         }
         return value.trim();
     }

--- a/backend/src/main/java/com/glossaar/backend/word/WordService.java
+++ b/backend/src/main/java/com/glossaar/backend/word/WordService.java
@@ -1,5 +1,6 @@
 package com.glossaar.backend.word;
 
+import com.glossaar.backend.ValidationException;
 import com.glossaar.backend.category.CategoryEntity;
 import com.glossaar.backend.category.CategoryService;
 import com.glossaar.backend.user.UserEntity;
@@ -27,10 +28,10 @@ public class WordService {
 
     public Page<WordEntity> getAll(UserEntity user, String search, int page, int size, String sortBy, String sortDir) {
         if (page < 0) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "page must be >= 0");
+            throw new ValidationException("page: negative");
         }
         if (size < 1 || size > 100) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "size must be between 1 and 100");
+            throw new ValidationException("size: outOfRange", "1", "100");
         }
 
         String normalizedSearch = search == null ? "" : search.trim();
@@ -58,10 +59,7 @@ public class WordService {
         String value = sortBy.trim().toLowerCase();
         return switch (value) {
             case "word", "explanation", "id" -> value;
-            default -> throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST,
-                    "sortBy must be one of: word, explanation, id"
-            );
+            default -> throw new ValidationException("sortBy: invalid");
         };
     }
 
@@ -73,7 +71,7 @@ public class WordService {
         return switch (value) {
             case "asc" -> Sort.Direction.ASC;
             case "desc", "dsc" -> Sort.Direction.DESC;
-            default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "sortDir must be asc or desc");
+            default -> throw new ValidationException("sortDir: invalid");
         };
     }
 
@@ -138,7 +136,7 @@ public class WordService {
 
     private static String requireNonBlank(String field, String value) {
         if (value == null || value.trim().isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, field + " must not be blank");
+            throw new ValidationException("field: blank", field);
         }
         return value.trim();
     }

--- a/backend/src/test/java/com/glossaar/backend/category/CategoryControllerTest.java
+++ b/backend/src/test/java/com/glossaar/backend/category/CategoryControllerTest.java
@@ -1,6 +1,7 @@
 package com.glossaar.backend.category;
 
 import com.glossaar.backend.IntegrationTest;
+import com.glossaar.backend.ValidationException;
 import com.glossaar.backend.category.dto.CategoryResponseDto;
 import com.glossaar.backend.category.dto.CategoryUpdateDto;
 import com.glossaar.backend.userword.UserWordScoreRepository;
@@ -9,8 +10,6 @@ import com.glossaar.backend.word.WordRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -93,11 +92,12 @@ class CategoryControllerTest extends IntegrationTest {
         assertEquals(1, allCategoriesBeforeUpdate.size());
         assertEquals(existingCategory, allCategoriesBeforeUpdate.get(0));
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        ValidationException exception = assertThrows(ValidationException.class, () -> {
             controller.update(existingCategory.getId(), new CategoryUpdateDto("   "), testUserPrincipal);
         });
 
-        assertEquals("Category name cannot be empty", exception.getMessage());
+        assertEquals("field: blank", exception.getMessage());
+        assertThat(exception.getArgs()).containsExactly("name");
 
         List<CategoryEntity> allCategoriesAfterUpdate = categoryRepository.findAll();
         assertEquals(1, allCategoriesAfterUpdate.size());
@@ -128,12 +128,12 @@ class CategoryControllerTest extends IntegrationTest {
         word.setCategory(food);
         wordRepository.save(word);
 
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+        ValidationException exception = assertThrows(ValidationException.class, () -> {
             controller.delete(food.getId(), testUserPrincipal);
         });
 
-        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(exception.getReason()).contains("Cannot delete category: 1 words reference it");
+        assertThat(exception.getMessage()).isEqualTo("category: hasWords");
+        assertThat(exception.getArgs()).containsExactly("1");
 
         List<CategoryEntity> allCategoriesAfterDelete = categoryRepository.findAll();
         assertEquals(1, allCategoriesAfterDelete.size());

--- a/backend/src/test/java/com/glossaar/backend/category/CategoryServiceTest.java
+++ b/backend/src/test/java/com/glossaar/backend/category/CategoryServiceTest.java
@@ -1,6 +1,7 @@
 package com.glossaar.backend.category;
 
 import com.glossaar.backend.IntegrationTest;
+import com.glossaar.backend.ValidationException;
 import com.glossaar.backend.userword.UserWordScoreRepository;
 import com.glossaar.backend.word.WordRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -85,11 +86,11 @@ class CategoryServiceTest extends IntegrationTest {
 
     @Test
     void create_throwsWhenBlankName() {
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+        ValidationException exception = assertThrows(ValidationException.class, () -> {
             service.create("      ", testUser);
         });
 
-        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(exception.getReason()).contains("name must not be blank");
+        assertThat(exception.getMessage()).isEqualTo("field: blank");
+        assertThat(exception.getArgs()).containsExactly("name");
     }
 }

--- a/backend/src/test/java/com/glossaar/backend/word/WordControllerTest.java
+++ b/backend/src/test/java/com/glossaar/backend/word/WordControllerTest.java
@@ -1,6 +1,7 @@
 package com.glossaar.backend.word;
 
 import com.glossaar.backend.IntegrationTest;
+import com.glossaar.backend.ValidationException;
 import com.glossaar.backend.word.dto.CreateWordRequestDto;
 import com.glossaar.backend.word.dto.GetWordsResponseDto;
 import com.glossaar.backend.word.dto.WordResponseDto;
@@ -10,8 +11,6 @@ import com.glossaar.backend.userword.UserWordScoreRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -99,12 +98,12 @@ class WordControllerTest extends IntegrationTest {
             "Bar"
         );
 
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+        ValidationException exception = assertThrows(ValidationException.class, () -> {
             controller.create(request, testUserPrincipal);
         });
 
-        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(exception.getReason()).contains("word must not be blank");
+        assertThat(exception.getMessage()).isEqualTo("field: blank");
+        assertThat(exception.getArgs()).containsExactly("word");
 
         List<CategoryEntity> categories = categoryRepository.findAll();
         List<WordEntity> words = wordRepository.findAll();
@@ -120,12 +119,12 @@ class WordControllerTest extends IntegrationTest {
             "Bar"
         );
 
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+        ValidationException exception = assertThrows(ValidationException.class, () -> {
             controller.create(request, testUserPrincipal);
         });
 
-        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(exception.getReason()).contains("explanation must not be blank");
+        assertThat(exception.getMessage()).isEqualTo("field: blank");
+        assertThat(exception.getArgs()).containsExactly("explanation");
 
         List<CategoryEntity> categories = categoryRepository.findAll();
         List<WordEntity> words = wordRepository.findAll();
@@ -141,12 +140,12 @@ class WordControllerTest extends IntegrationTest {
             "   "
         );
 
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+        ValidationException exception = assertThrows(ValidationException.class, () -> {
             controller.create(request, testUserPrincipal);
         });
 
-        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(exception.getReason()).contains("category must not be blank");
+        assertThat(exception.getMessage()).isEqualTo("field: blank");
+        assertThat(exception.getArgs()).containsExactly("category");
 
         List<CategoryEntity> categories = categoryRepository.findAll();
         List<WordEntity> words = wordRepository.findAll();

--- a/frontend/src/lib/api/glossarClient.ts
+++ b/frontend/src/lib/api/glossarClient.ts
@@ -26,10 +26,10 @@ export interface Category {
 }
 
 export interface QuizQuestion {
-  wordId: number;
-  word: string;
-  options: string[];
-  correctIndex: number;
+    wordId: number;
+    word: string;
+    options: string[];
+    correctIndex: number;
 }
 
 export interface ExplanationGroup {
@@ -47,13 +47,43 @@ export interface MeResponse {
 }
 
 const API_BASE = '/api';
+const VALIDATION_PREFIX = 'ValidationException.';
+
+export class ValidationError extends Error {
+    readonly key: string;
+    readonly args: string[];
+    constructor(key: string, args: string[]) {
+        super(key);
+        this.name = 'ValidationError';
+        this.key = key;
+        this.args = args;
+    }
+}
+
+async function throwIfError(response: Response, fallbackKey: string): Promise<void> {
+    if (response.ok) return;
+
+    let body: unknown = null;
+    try {
+        body = await response.json();
+    } catch {
+        body = null;
+    }
+
+    const error = (body as { error?: string } | null)?.error;
+    if (typeof error === 'string' && error.startsWith(VALIDATION_PREFIX)) {
+        const key = error.slice(VALIDATION_PREFIX.length);
+        const args = (body as { args?: unknown }).args;
+        throw new ValidationError(key, Array.isArray(args) ? args.map(String) : []);
+    }
+
+    throw new ValidationError(fallbackKey, [String(response.status)]);
+}
 
 export const GlossarClient = {
     async getCategories(): Promise<Category[]> {
         const response = await fetch(`${API_BASE}/categories`);
-        if (!response.ok) {
-            throw new Error(`Failed to fetch categories: ${response.status}`);
-        }
+        await throwIfError(response, 'categories: loadFailed');
         return response.json();
     },
 
@@ -64,11 +94,7 @@ export const GlossarClient = {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ name })
         });
-
-        if (!response.ok) {
-            const text = await response.text().catch(() => '');
-            throw new Error(`Failed to save category: ${response.status} ${text}`);
-        }
+        await throwIfError(response, 'category: updateFailed');
     },
 
     async deleteCategory(id: number): Promise<void> {
@@ -76,18 +102,7 @@ export const GlossarClient = {
             method: 'DELETE',
             credentials: 'include'
         });
-
-        if (!response.ok) {
-            let message = `Failed to delete category (${response.status})`;
-            try {
-                const data = await response.json();
-                if (data?.message) message = data.message;
-            } catch {
-                const text = await response.text();
-                if (text) message = text;
-            }
-            throw new Error(message);
-        }
+        await throwIfError(response, 'category: deleteFailed');
     },
 
     async createWord(word: string, explanation: string, categoryName: string) {
@@ -101,12 +116,7 @@ export const GlossarClient = {
                 categoryName
             })
         });
-
-        if (!response.ok) {
-            const errorText = await response.text();
-            throw new Error(`Failed to create word: ${response.status} ${errorText}`);
-        }
-
+        await throwIfError(response, 'word: createFailed');
         return response.json() as Promise<Word>;
     },
 
@@ -115,10 +125,7 @@ export const GlossarClient = {
             method: 'DELETE',
             credentials: 'include'
         });
-
-        if (!response.ok) {
-            throw new Error(`Failed to delete word: ${response.status}`);
-        }
+        await throwIfError(response, 'word: deleteFailed');
     },
 
     async updateWord(id: number, payload: {
@@ -132,10 +139,7 @@ export const GlossarClient = {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)
         });
-
-        if (!response.ok) {
-            throw new Error(`Failed to update word: ${response.status}`);
-        }
+        await throwIfError(response, 'word: updateFailed');
     },
 
 
@@ -157,11 +161,7 @@ export const GlossarClient = {
         const response = await fetch(`${API_BASE}/words?${query.toString()}`, {
             credentials: 'include'
         });
-
-        if (!response.ok) {
-            throw new Error(`Failed to fetch words: ${response.status}`);
-        }
-
+        await throwIfError(response, 'words: loadFailed');
         return response.json();
     },
 
@@ -169,9 +169,7 @@ export const GlossarClient = {
         const response = await fetch(`${API_BASE}/quiz?size=1`, {
             credentials: 'include'
         });
-        if (!response.ok) {
-            throw new Error(`Failed to fetch quiz question: ${response.status}`);
-        }
+        await throwIfError(response, 'quiz: loadFailed');
         const questions: QuizQuestion[] = await response.json();
         return questions[0];
     },
@@ -185,25 +183,19 @@ export const GlossarClient = {
                 answers: [{ wordId, correct }]
             })
         });
-        if (!response.ok) {
-            throw new Error(`Failed to submit quiz answer: ${response.status}`);
-        }
+        await throwIfError(response, 'quiz: submitFailed');
     },
 
     async fetchEkiExplanations(word: string): Promise<ExplanationGroup[]> {
         const response = await fetch(`${API_BASE}/eki/explanations/${encodeURIComponent(word)}`);
-        if (!response.ok) {
-            throw new Error(`EKI explanation lookup failed: ${response.status}`);
-        }
+        await throwIfError(response, 'eki: lookupFailed');
         const data: { word: string; explanationGroups: ExplanationGroup[] } = await response.json();
         return data.explanationGroups;
     },
 
     async fetchWordnikExplanations(word: string): Promise<ExplanationGroup[]> {
         const response = await fetch(`${API_BASE}/wordnik/explanations/${encodeURIComponent(word)}`);
-        if (!response.ok) {
-            throw new Error(`Wordnik explanation lookup failed: ${response.status}`);
-        }
+        await throwIfError(response, 'wordnik: lookupFailed');
         const data: { word: string; explanationGroups: ExplanationGroup[] } = await response.json();
         return data.explanationGroups;
     },
@@ -212,11 +204,7 @@ export const GlossarClient = {
         const response = await fetch(`${API_BASE}/auth/me`, {
             credentials: 'include'
         });
-
-        if (!response.ok) {
-            throw new Error(`Failed to fetch user info: ${response.status}`);
-        }
-
+        await throwIfError(response, 'auth: meFailed');
         return response.json();
     },
 };

--- a/frontend/src/lib/components/AddPage/AddForm.svelte
+++ b/frontend/src/lib/components/AddPage/AddForm.svelte
@@ -196,6 +196,7 @@
     import { _ } from 'svelte-i18n';
     import { toast } from '$lib/stores/toast';
     import type { SupportedLocale } from '$lib/i18n';
+    import { translateError } from '$lib/i18n/translateError';
 
     type LocaleObj = {
         code: SupportedLocale;
@@ -250,7 +251,7 @@
             await GlossarClient.updateCategory(category.id, category.name);
             toast.success($_('add.categoryUpdated'));
         } catch (err) {
-            toast.error(err instanceof Error ? err.message : $_('add.failedUpdateCategory'));
+            toast.error(translateError(err, 'category: updateFailed'));
         }
     }
 
@@ -259,7 +260,7 @@
         try {
             await reloadCategories();
         } catch (err) {
-            toast.error($_('add.failedReloadCategories'));
+            toast.error(translateError(err, 'categories: loadFailed'));
         }
     }
 
@@ -324,12 +325,12 @@
             try {
                 await reloadCategories();
             } catch (err) {
-                toast.error($_('add.failedReloadCategories'));
+                toast.error(translateError(err, 'categories: loadFailed'));
             }
 
             toast.success($_('add.wordSaved'));
         } catch (err) {
-            toast.error($_('add.errorSavingWord'));
+            toast.error(translateError(err, 'word: createFailed'));
         } finally {
             loading = false;
         }
@@ -344,7 +345,7 @@
 
             toast.success($_('add.categoryDeleted'));
         } catch (err) {
-            toast.error(err instanceof Error ? err.message : $_('add.failedDeleteCategory'));
+            toast.error(translateError(err, 'category: deleteFailed'));
         }
     }
 

--- a/frontend/src/lib/components/ListPage/List.svelte
+++ b/frontend/src/lib/components/ListPage/List.svelte
@@ -5,6 +5,7 @@
     import EditWordModal from '$lib/components/EditWordModal.svelte';
     import {GlossarClient} from "$lib/api/glossarClient";
     import { _ } from 'svelte-i18n';
+    import { translateError } from '$lib/i18n/translateError';
     import Button from '$lib/components/ui/button/button.svelte';
     import { toast } from '$lib/stores/toast';
 
@@ -60,7 +61,7 @@
             sortBy = data.sortBy || sortBy;
             sortDir = data.sortDir || sortDir;
         } catch (e) {
-            toast.error(e instanceof Error ? e.message : String(e));
+            toast.error(translateError(e, 'words: loadFailed'));
         } finally {
             wordsLoading = false;
         }
@@ -111,7 +112,7 @@
             toast.success($_('list.deletedToast', { values: { word: target.word } }));
             await loadWords(fallbackPage);
         } catch (e) {
-            toast.error(e instanceof Error ? e.message : String(e));
+            toast.error(translateError(e, 'word: deleteFailed'));
         } finally {
             deleteLoading = false;
         }
@@ -146,7 +147,7 @@
             toast.success($_('list.updatedToast', { values: { word: payload.word } }));
             await loadWords(page);
         } catch (e) {
-            toast.error(e instanceof Error ? e.message : String(e));
+            toast.error(translateError(e, 'word: updateFailed'));
         } finally {
             editLoading = false;
         }

--- a/frontend/src/lib/components/QuizPage/Quiz.svelte
+++ b/frontend/src/lib/components/QuizPage/Quiz.svelte
@@ -5,6 +5,7 @@
     import Button from '$lib/components/ui/button/button.svelte';
     import { _ } from 'svelte-i18n';
     import { toast } from '$lib/stores/toast';
+    import { translateError } from '$lib/i18n/translateError';
 
     type Status = 'loading' | 'ready' | 'empty' | 'submitting' | 'error';
 
@@ -38,7 +39,7 @@
             question = await GlossarClient.getQuizQuestion() ?? null;
             status = question ? 'ready' : 'empty';
         } catch (e) {
-            error = e instanceof Error ? e.message : $_('quiz.failedLoad');
+            error = translateError(e, 'request: failed');
             status = 'error';
         }
     }
@@ -49,7 +50,7 @@
         try {
             await GlossarClient.submitQuizAnswer(question.wordId, selected === question.correctIndex);
         } catch (e) {
-            toast.error(e instanceof Error ? e.message : $_('quiz.failedSave'));
+            toast.error(translateError(e, 'quiz: submitFailed'));
         }
         await loadQuestion();
     }

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -54,14 +54,10 @@
         "usedInWords": "Used in {count} word(s)",
         "selectOrEnterCategory": "Please select or enter a category.",
         "wordSaved": "Word saved successfully!",
-        "errorSavingWord": "Error saving word.",
         "categoryUpdated": "Category updated!",
         "categoryDeleted": "Category deleted!",
         "confirmDeleteCategory": "Delete category \"{name}\"?",
-        "invalidCategoryId": "Invalid category ID",
-        "failedReloadCategories": "Failed to reload categories",
-        "failedUpdateCategory": "Failed to update category",
-        "failedDeleteCategory": "Failed to delete category"
+        "invalidCategoryId": "Invalid category ID"
     },
     "list": {
         "search": "Search",
@@ -97,10 +93,7 @@
     },
     "quiz": {
         "empty": "Add some words to your dictionary to start quizzing!",
-        "whatIs": "What is:",
-        "answerNotSaved": "Answer may not have been saved — {error}",
-        "failedLoad": "Failed to load question",
-        "failedSave": "Failed to save answer"
+        "whatIs": "What is:"
     },
     "confirm": {
         "defaultTitle": "Please confirm"
@@ -109,5 +102,42 @@
         "label": "Lang: {code}",
         "et": "Eesti",
         "en": "English"
+    },
+    "fields": {
+        "word": "Word",
+        "category": "Category",
+        "explanation": "Explanation",
+        "name": "Name",
+        "username": "Username"
+    },
+    "errors": {
+        "field: blank": "{0} must not be blank",
+        "page: negative": "Page must be 0 or greater",
+        "size: outOfRange": "Size must be between {0} and {1}",
+        "sortBy: invalid": "Invalid sort field",
+        "sortDir: invalid": "Sort direction must be ascending or descending",
+        "answers: tooMany": "You can submit at most {0} answers at once",
+        "answers: duplicateWordId": "Duplicate answers detected",
+
+        "username: exists": "Username already exists",
+        "category: hasWords": "Cannot delete: {0} word(s) still use this category",
+
+        "quiz: notEnoughWords": "You need at least {0} words with explanations to start a quiz",
+        "quiz: notEnoughDistractors": "Add more unique explanations to your dictionary to enable quizzes",
+
+        "request: failed": "Request failed. Please try again.",
+        "lookup: failed": "Lookup failed. Please try again.",
+        "categories: loadFailed": "Failed to load categories ({0})",
+        "category: updateFailed": "Failed to update category ({0})",
+        "category: deleteFailed": "Failed to delete category ({0})",
+        "word: createFailed": "Failed to create word ({0})",
+        "word: updateFailed": "Failed to update word ({0})",
+        "word: deleteFailed": "Failed to delete word ({0})",
+        "words: loadFailed": "Failed to load words ({0})",
+        "quiz: loadFailed": "Failed to load quiz question ({0})",
+        "quiz: submitFailed": "Failed to submit answer ({0})",
+        "eki: lookupFailed": "EKI explanation lookup failed ({0})",
+        "wordnik: lookupFailed": "Wordnik explanation lookup failed ({0})",
+        "auth: meFailed": "Failed to fetch user info ({0})"
     }
 }

--- a/frontend/src/lib/i18n/locales/et.json
+++ b/frontend/src/lib/i18n/locales/et.json
@@ -54,14 +54,10 @@
         "usedInWords": "Kasutusel {count} sõnas",
         "selectOrEnterCategory": "Palun vali või sisesta kategooria.",
         "wordSaved": "Sõna salvestatud!",
-        "errorSavingWord": "Viga sõna salvestamisel.",
         "categoryUpdated": "Kategooria uuendatud!",
         "categoryDeleted": "Kategooria kustutatud!",
         "confirmDeleteCategory": "Kas kustutada kategooria \"{name}\"?",
-        "invalidCategoryId": "Vigane kategooria ID",
-        "failedReloadCategories": "Kategooriate laadimine ebaõnnestus",
-        "failedUpdateCategory": "Kategooria uuendamine ebaõnnestus",
-        "failedDeleteCategory": "Kategooria kustutamine ebaõnnestus"
+        "invalidCategoryId": "Vigane kategooria ID"
     },
     "list": {
         "search": "Otsing",
@@ -97,10 +93,7 @@
     },
     "quiz": {
         "empty": "Lisa oma sõnastikku sõnu, et alustada viktoriini!",
-        "whatIs": "Mis on:",
-        "answerNotSaved": "Vastust ei pruugitud salvestada — {error}",
-        "failedLoad": "Küsimuse laadimine ebaõnnestus",
-        "failedSave": "Vastuse salvestamine ebaõnnestus"
+        "whatIs": "Mis on:"
     },
     "confirm": {
         "defaultTitle": "Palun kinnita"
@@ -109,5 +102,42 @@
         "label": "Keel: {code}",
         "et": "Eesti",
         "en": "English"
+    },
+    "fields": {
+        "word": "Sõna",
+        "category": "Kategooria",
+        "explanation": "Selgitus",
+        "name": "Nimi",
+        "username": "Kasutajanimi"
+    },
+    "errors": {
+        "field: blank": "{0} ei tohi olla tühi",
+        "page: negative": "Lehekülje number peab olema 0 või suurem",
+        "size: outOfRange": "Suurus peab olema vahemikus {0} kuni {1}",
+        "sortBy: invalid": "Vigane sorteerimisväli",
+        "sortDir: invalid": "Sorteerimissuund peab olema kasvav või kahanev",
+        "answers: tooMany": "Korraga saab esitada kuni {0} vastust",
+        "answers: duplicateWordId": "Tuvastati korduvad vastused",
+
+        "username: exists": "Kasutajanimi on juba kasutusel",
+        "category: hasWords": "Ei saa kustutada: {0} sõna kasutab seda kategooriat",
+
+        "quiz: notEnoughWords": "Viktoriini alustamiseks on vaja vähemalt {0} sõna selgitustega",
+        "quiz: notEnoughDistractors": "Lisa rohkem unikaalseid selgitusi, et viktoriin oleks võimalik",
+
+        "request: failed": "Päring ebaõnnestus. Palun proovi uuesti.",
+        "lookup: failed": "Otsing ebaõnnestus. Palun proovi uuesti.",
+        "categories: loadFailed": "Kategooriate laadimine ebaõnnestus ({0})",
+        "category: updateFailed": "Kategooria uuendamine ebaõnnestus ({0})",
+        "category: deleteFailed": "Kategooria kustutamine ebaõnnestus ({0})",
+        "word: createFailed": "Sõna lisamine ebaõnnestus ({0})",
+        "word: updateFailed": "Sõna uuendamine ebaõnnestus ({0})",
+        "word: deleteFailed": "Sõna kustutamine ebaõnnestus ({0})",
+        "words: loadFailed": "Sõnade laadimine ebaõnnestus ({0})",
+        "quiz: loadFailed": "Küsimuse laadimine ebaõnnestus ({0})",
+        "quiz: submitFailed": "Vastuse salvestamine ebaõnnestus ({0})",
+        "eki: lookupFailed": "EKI selgituse otsing ebaõnnestus ({0})",
+        "wordnik: lookupFailed": "Wordniku selgituse otsing ebaõnnestus ({0})",
+        "auth: meFailed": "Kasutaja andmete laadimine ebaõnnestus ({0})"
     }
 }

--- a/frontend/src/lib/i18n/translateError.ts
+++ b/frontend/src/lib/i18n/translateError.ts
@@ -1,0 +1,13 @@
+import { get } from 'svelte/store';
+import { _ } from 'svelte-i18n';
+import { ValidationError } from '$lib/api/glossarClient';
+
+export function translateError(err: unknown, fallbackKey = 'request: failed'): string {
+    const t = get(_);
+    if (err instanceof ValidationError) {
+        const localizedArgs = err.args.map((arg) => t(`fields.${arg}`, { default: arg }));
+        const values = Object.fromEntries(localizedArgs.map((v, i) => [String(i), v]));
+        return t(`errors.${err.key}`, { values, default: t(`errors.${fallbackKey}`) });
+    }
+    return t(`errors.${fallbackKey}`);
+}

--- a/frontend/src/lib/services/categoryService.ts
+++ b/frontend/src/lib/services/categoryService.ts
@@ -1,10 +1,5 @@
 import { GlossarClient } from '$lib/api/glossarClient';
 
 export async function fetchCategories() {
-    try {
-        return await GlossarClient.getCategories();
-    } catch (err) {
-        console.error('Failed to fetch categories', err);
-        throw new Error('Could not load categories');
-    }
+    return GlossarClient.getCategories();
 }

--- a/frontend/src/lib/stores/auth.ts
+++ b/frontend/src/lib/stores/auth.ts
@@ -1,5 +1,6 @@
 import { writable, derived } from 'svelte/store';
 import { GlossarClient, type MeResponse } from '$lib/api/glossarClient';
+import { translateError } from '$lib/i18n/translateError';
 
 type AuthState = {
     user: MeResponse | null;
@@ -22,7 +23,7 @@ function createAuthStore() {
                 const user = await GlossarClient.getMe();
                 update((state) => ({ ...state, user, loading: false, error: null }));
             } catch (err) {
-                const error = err instanceof Error ? err.message : 'Auth failed';
+                const error = translateError(err, 'request: failed');
                 update((state) => ({ ...state, user: null, loading: false, error }));
             }
         },
@@ -32,7 +33,7 @@ function createAuthStore() {
                 update((state) => ({ ...state, user: null, error: null }));
                 // TODO: purge session cookie on backend
             } catch (err) {
-                const error = err instanceof Error ? err.message : 'Logout failed';
+                const error = translateError(err, 'request: failed');
                 update((state) => ({ ...state, error }));
             }
         }


### PR DESCRIPTION
Backend services now throw ValidationException with a stable error key and positional args (e.g. "field: blank" + "word", "size: outOfRange" + "1" + "100"). ApiExceptionHandler serializes these as ValidationException.<key> with the args array, and the frontend glossarClient parses them into a ValidationError.

A shared translateError helper resolves the key against the errors namespace in en.json / et.json and substitutes the args, looking each arg up in a new fields namespace first so backend field names render localized ("Sõna ei tohi olla tühi" rather than "word ei tohi olla tühi"). All catch blocks across Quiz, List, AddForm and the auth store route through translateError with a per-call fallback key.